### PR TITLE
Document Crockett thermal qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,14 @@ token context, automatic layer split, Bowie local Vulkan plus Crockett RPC, and
 For Hermes Agent, the current recommendation is
 `Qwen3-Coder-30B-A3B-Instruct-Q4_K_M` with a 65,536-token context, Q8_0 K/V
 cache, both GPUs, and automatic layer split. It loaded and completed the 64K
-tests, but sustained thermal qualification is still pending: Crockett reached
-approximately 90°C and throttled while Bowie remained substantially cooler.
-The physical cooling changes described in
-[Hardware preparation](docs/hardware-prep.md) have since been made, but the
-same test has not yet been rerun. Do not hide this cooling limitation by
-raising thermal limits or changing the validated software profile.
+tests. In the original sustained run, Crockett reached approximately 90°C and
+throttled while Bowie peaked at 67°C. After the physical cooling changes in
+[Hardware preparation](docs/hardware-prep.md), the equivalent 18,976-token
+prompt plus 1,024-token generation qualification peaked at 61°C on Bowie and
+66°C on Crockett. Both GPUs held 1750 MHz without thermal throttling, GPU
+errors, resets, or RPC failures. Crockett therefore passes sustained thermal
+qualification for this workload without a software-profile or thermal-limit
+change.
 
 See [the deployed-state record](docs/current-state.md) and the complete
 [Hermes model bake-off](docs/hermes-model-bakeoff.md).

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -90,12 +90,16 @@ ran at 64K, but its tighter memory margin, slower generation, and aggressive
 quantization make it the fallback rather than the default. Hermes-4-14B is
 limited to 40,960 tokens and does not meet the intended Hermes requirement.
 
-The 64K Qwen3-Coder-30B run was functionally successful, but Crockett reached
-approximately 90°C and throttled while Bowie stayed substantially cooler.
-Thermal-interface replacement, a rear heatsink, and increased physical board
-separation are planned. Sustained thermal qualification remains pending a rerun
-after those physical cooling improvements; no software profile reduction or
-thermal-limit increase is being used to conceal the result.
+The original 64K Qwen3-Coder-30B run was functionally successful, but Crockett
+reached approximately 90°C and throttled while Bowie peaked at 67°C. After
+thermal-interface replacement, a rear heatsink, and increased physical board
+separation, the sustained qualification was repeated with the same model,
+llama.cpp revision, 65,536 context, Q8_0 K/V, one slot, and automatic split.
+Crockett peaked at 66°C, averaged 62.5°C during late-prompt heat soak, and held
+1750 MHz without throttling. Bowie peaked at 61°C. Generation remained within
+normal variance at 77.10 tokens/s, and no GPU reset, fault, RPC error, or
+backend timeout occurred. Crockett now passes sustained thermal qualification
+without a software-profile or thermal-limit change.
 
 Router mode discovers models at service startup. Restart
 `llama-server.service` after adding another GGUF to the model directory.

--- a/docs/hardware-prep.md
+++ b/docs/hardware-prep.md
@@ -69,12 +69,14 @@ Before enabling performance tuning or unattended workloads:
 - Verify that power connectors and wiring are not overheating.
 - Qualify each board individually before enabling persistent 40-CU routing.
 
-During the recorded sustained 64K Qwen3-Coder test, Crockett reached
-approximately 90°C and throttled while Bowie remained substantially cooler.
-The physical setup listed above includes the cooling remediation made for the
-next qualification run, but the same sustained benchmark has not yet been
-rerun. The cluster therefore remains pending final sustained thermal
-qualification.
+During the original sustained 64K Qwen3-Coder test, Crockett reached
+approximately 90°C and throttled while Bowie peaked at 67°C. After the physical
+cooling remediation listed above, the equivalent 18,976-token prompt plus
+1,024-token generation qualification peaked at 66°C on Crockett and 61°C on
+Bowie. Crockett's late-prompt heat-soak temperature averaged 62.5°C, both GPUs
+held 1750 MHz, and neither node throttled or produced a GPU, kernel, RPC, or
+network error. The 24°C reduction qualifies this physical setup for the tested
+sustained Hermes workload.
 
 My hardware configuration is an example, not a universal BC250 cooling
 specification or proof that another board is safe under the same workload.

--- a/docs/hermes-model-bakeoff.md
+++ b/docs/hermes-model-bakeoff.md
@@ -66,6 +66,47 @@ No GPU reset, VM/page fault, ring timeout, allocation failure, new MCE, or other
 AMDGPU/kernel hardware error was found. Both governor services and the
 coordinator/RPC services remained active.
 
+## Post-cooling thermal qualification
+
+The sustained Qwen3-Coder-30B automatic-split test was repeated on 2026-08-23
+after Crockett received the physical cooling changes described in
+[Hardware preparation](hardware-prep.md). The software baseline was unchanged:
+llama.cpp commit `d775b8967a46d8beb110d444aa3b8938179e0dd8`, the same verified
+Q4_K_M GGUF, 65,536 context, Q8_0 K/V, one slot, all layers offloaded, and no
+manual tensor split. Telemetry sampled both nodes once per second.
+
+The original private prompt artifact was not retained. The rerun therefore
+used a deterministic synthetic payload with the same 18,976-token prompt count,
+followed immediately by a separate 1,024-token generation request. This keeps
+the thermal load, allocation, context, and generation length comparable, but
+the prompt-throughput change is not a controlled model-quality comparison.
+
+| Metric | Original | Post-cooling | Change |
+| --- | ---: | ---: | ---: |
+| Bowie peak temperature | 67°C | 61°C | -6°C |
+| Crockett peak temperature | 90°C | **66°C** | **-24°C** |
+| Bowie peak PPT | 135.31 W | 137.02 W | +1.71 W |
+| Crockett peak PPT | 131.09 W | 128.74 W | -2.35 W |
+| Prompt processing | 377.96 tok/s | 420.25 tok/s | +11.2%[^prompt-comparison] |
+| Generation | 77.89 tok/s | 77.10 tok/s | -1.0% |
+| Stream first event | 3.34 s | 3.71 s | +0.37 s |
+| Vulkan allocation, Bowie / Crockett | 10.20 / 10.62 GiB | 10.23 / 10.62 GiB | Comparable |
+| Free Vulkan, Bowie / Crockett | 1,837 / 1,409 MiB | 1,808 / 1,412 MiB | Comparable |
+| Crockett thermal throttling | Yes | **No** | Eliminated |
+| GPU resets, faults, RPC errors | None | None | No change |
+
+[^prompt-comparison]: The post-cooling payload preserved the token count but
+    not the unavailable original prompt contents, so the apparent prompt-rate
+    improvement is not attributed to cooling. Generation remained within
+    normal run-to-run variance.
+
+Crockett averaged 62.5°C during the late prompt heat-soak window and remained
+at 1750 MHz in every one-second workload sample. Bowie averaged 58.9°C over the
+same window. No thermal event, severe clock drop, GPU reset, VM/page fault,
+ring timeout, RPC disconnect, or backend timeout occurred. The five-degree
+peak difference is sufficiently balanced for unattended Hermes Agent use under
+this qualified workload.
+
 ## Split experiment
 
 llama.cpp lists the RPC device before Bowie's local device for `--tensor-split`.
@@ -111,13 +152,12 @@ result would not establish suitability for the required 64K Hermes workload.
    important thermal and memory-pressure warnings above.
 
 Use **Qwen3-Coder-30B-A3B-Instruct Q4_K_M** as the default model selection, with
-65,536 context, Q8_0 K/V cache, and automatic split. However, neither true-64K
-candidate passed the long-prompt run without Crockett exceeding the 80°C target
-and throttling. Treat the selection as functionally correct but not yet
-thermally qualified for unattended sustained Hermes workloads. Thermal-interface
-replacement, a rear heatsink, and increased physical separation from Bowie are
-planned, followed by a repeat of the same benchmark. Do not raise clocks,
-voltage, power, or thermal limits to mask this pending cooling work.
+65,536 context, Q8_0 K/V cache, and automatic split. The original bake-off
+established the model recommendation but exposed Crockett's cooling failure.
+The post-cooling rerun eliminated that throttling without changing clocks,
+voltage, power, thermal limits, or the software profile, so this configuration
+is now sustained-thermally qualified for unattended Hermes workloads on the
+documented hardware.
 
 Hermes-4 Q6_K and Q8_0 are **NOT VIABLE FOR HERMES ON CURRENT HARDWARE AND
 REQUIRED CONTEXT** because the server caps them to 40,960 tokens. Qwen3-Coder-


### PR DESCRIPTION
Record the post-cooling sustained 64K Hermes workload results. Crockett peaked at 66 C without throttling, a 24 C reduction from the original run, while the validated software and performance baseline remained unchanged.\n\nNote the synthetic-prompt comparability limitation and retain the original failed run as historical evidence.