### PR TITLE
Require qualified BC250 cooling

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,4 @@
 profile: production
 exclude_paths:
   - .ansible/
+  - benchmarks/private/

--- a/.yamllint
+++ b/.yamllint
@@ -3,6 +3,7 @@ extends: default
 
 ignore: |
   .ansible/
+  benchmarks/private/
   inventories/production/
 
 rules:

--- a/README.md
+++ b/README.md
@@ -125,20 +125,18 @@ token context, automatic layer split, Bowie local Vulkan plus Crockett RPC, and
 | Bowie peak | 1750 MHz, 49°C, 85.39 W PPT |
 | Crockett peak | 1750 MHz, 66°C, 80.34 W PPT |
 
-For Hermes Agent, the current recommendation is
-`Qwen3-Coder-30B-A3B-Instruct-Q4_K_M` with a 65,536-token context, Q8_0 K/V
-cache, both GPUs, and automatic layer split. It loaded and completed the 64K
-tests. In the original sustained run, Crockett reached approximately 90°C and
-throttled while Bowie peaked at 67°C. After the physical cooling changes in
-[Hardware preparation](docs/hardware-prep.md), the equivalent 18,976-token
-prompt plus 1,024-token generation qualification peaked at 61°C on Bowie and
-66°C on Crockett. Both GPUs held 1750 MHz without thermal throttling, GPU
-errors, resets, or RPC failures. Crockett therefore passes sustained thermal
-qualification for this workload without a software-profile or thermal-limit
-change.
+For Hermes Agent, the deployed recommendation is `Qwen3.6-35B-A3B-Q4_K_M`
+with a 65,536-token context, Q8_0 K/V cache, one slot, both GPUs, and automatic
+layer split. Cross-request host-RAM prompt caching is disabled while the normal
+Q8_0 K/V cache remains enabled. The qualified automatic fan curve held Bowie
+to 63°C and Crockett to 66°C during two consecutive 44,927-token prompt plus
+2,048-token generation passes. Both GPUs held 1750 MHz without thermal
+throttling, GPU errors, resets, or RPC failures.
 
 See [the deployed-state record](docs/current-state.md) and the complete
 [Hermes model bake-off](docs/hermes-model-bakeoff.md).
+Fan installation, qualification, rollback, and telemetry are documented in
+[Fan control](docs/fan-control.md).
 
 ## Hardware safety
 
@@ -200,9 +198,11 @@ ansible-lint
 yamllint .
 ```
 
-`site.yml` performs preflight, Fedora configuration, BC250 hardware management,
-networking, Vulkan installation, the pinned llama.cpp build, services, and
-validation. Read [operations](docs/operations.md), [architecture](docs/architecture.md),
+`site.yml` performs preflight, Fedora configuration, required BC250 cooling
+installation and live validation, BC250 hardware management, networking,
+Vulkan installation, the pinned llama.cpp build, services, and validation.
+Cooling failure stops the deployment before hardware tuning or sustained
+inference services. Read [operations](docs/operations.md), [architecture](docs/architecture.md),
 [performance tuning](docs/performance-tuning.md), and
 [troubleshooting](docs/troubleshooting.md) before targeting hardware.
 

--- a/docs/fan-control.md
+++ b/docs/fan-control.md
@@ -1,0 +1,71 @@
+# BC250 fan control
+
+The BC250 exposes an NCT6686D-compatible embedded controller at ISA address
+`0xa20`. Fedora's in-tree `nct6683` driver provides read-only sensors. Writable
+PWM support uses upstream `nct6687d` pinned at commit
+`4864fd681346119cf17417f82934a8ce05d88ff6`.
+
+The implementation was adapted from the current BC250 SteamOS Real Toolkit,
+which builds the same driver with `force=true`. This Fedora deployment uses a
+checksum-pinned source file, builds against the running stock kernel, exposes
+only the qualified channel with `fan_mask`, and manages loading and control
+through Ansible. Rerun the fan playbook after booting a new kernel so the
+module is built for it.
+
+## Safety gates
+
+Cooling is part of the normal `site.yml` dependency chain as
+`playbooks/15-cooling.yml`, immediately after base configuration and before CU,
+TTM, performance, Vulkan, llama.cpp, and inference services. It processes one
+board at a time and fails the deployment unless the configured channel has
+already been positively qualified and live PWM/RPM validation succeeds.
+
+For qualification or maintenance, the dedicated playbook hard-fails unless
+exactly one host is selected:
+
+```bash
+ansible-playbook -i inventories/production/hosts.yml \
+  playbooks/25-fan-control.yml --check --diff --limit bowie
+ansible-playbook -i inventories/production/hosts.yml \
+  playbooks/25-fan-control.yml --limit bowie
+```
+
+Before setting `bc250_fan_control_channel_validated: true`, record the fan's
+firmware-mode RPM, briefly command a higher PWM value, confirm the corresponding
+tachometer increase, and restore `pwmN_enable=2` in an unconditional cleanup
+path. Repeat on the second board only after restoring the first.
+
+The qualified production boards both use channel 2, labeled `Pump Fan`:
+
+| Node | Firmware RPM | Full-PWM RPM | Result |
+| --- | ---: | ---: | --- |
+| Bowie | 1716 | 3108 | channel 2 confirmed |
+| Crockett | 1697 | 3045 | channel 2 confirmed |
+
+Do not copy this assignment to an untested board.
+
+`bc250_cooling_bypass: true` is an explicit diagnostic bypass only. It skips
+cooling setup, marks the host non-production-qualified, and the cluster role
+refuses to enable RPC or coordinator services while the bypass is active.
+
+## Automatic curve and fail-safe behavior
+
+The conservative curve is 45% at 40°C, 55% at 55°C, 70% at 65°C, 90% at
+75°C, and 100% at 80°C. The controller interpolates using the hottest GPU edge
+temperature, updates every two seconds, and logs temperature, commanded fan
+percentage, and RPM every ten seconds.
+
+On a normal stop or controller error, it returns the EC to standard hwmon
+automatic mode (`pwm2_enable=2`). The systemd unit repeats that restoration in
+`ExecStopPost` and restarts after failures. A zero tachometer reading is a
+controller failure. A systemd watchdog also terminates a stalled controller so
+`ExecStopPost` can return the EC to firmware mode before restart.
+
+```bash
+sudo journalctl -u bc250-fan-control.service -f
+```
+
+The 2026-08-24 Qwen3.6 long-context qualification reached 63°C/2214 RPM on
+Bowie and 66°C/2285 RPM on Crockett. Both GPUs remained at the existing
+1750 MHz Moderate profile. No clocks, CU routing, TTM limits, kernel, Mesa, or
+thermal thresholds changed during qualification.

--- a/inventories/example/group_vars/bc250_cluster.yml
+++ b/inventories/example/group_vars/bc250_cluster.yml
@@ -43,10 +43,22 @@ llama_api_allowed_cidrs:
   - 192.0.2.0/24
 llama_gpu_layers: all
 llama_context_size: 8192
+llama_parallel_slots: 1
 llama_split_mode: layer
 llama_tensor_split: []
 llama_cache_type_k: q8_0
 llama_cache_type_v: q8_0
+
+# Cooling is mandatory for production. The public inventory intentionally does
+# not claim a PWM channel is qualified, so a hardware run fails before tuning
+# or inference rather than guessing a channel.
+bc250_cooling_required: true
+bc250_cooling_bypass: false
+bc250_fan_driver_enabled: true
+bc250_fan_control_enabled: true
+bc250_fan_control_channel: 2
+bc250_fan_control_fan_mask: 2
+bc250_fan_control_channel_validated: false
 
 # Safe public defaults: install the read-only/status tool, but do not change or
 # persist CU routing. Never copy another board's WGP table into these values.

--- a/playbooks/15-cooling.yml
+++ b/playbooks/15-cooling.yml
@@ -1,0 +1,42 @@
+---
+- name: Establish required BC250 cooling before hardware tuning
+  hosts: bc250_cluster
+  serial: 1
+  gather_facts: true
+  tags: [cooling, fan_control]
+  pre_tasks:
+    - name: Require cooling or an explicit non-production bypass
+      ansible.builtin.assert:
+        that:
+          - bc250_cooling_required | bool or bc250_cooling_bypass | bool
+        fail_msg: >-
+          Cooling is a production prerequisite. Set bc250_cooling_required=true,
+          or explicitly opt into the non-production bc250_cooling_bypass.
+
+    - name: Warn about non-production cooling bypass
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: cooling validation is bypassed. This host is not qualified
+          for sustained inference and production services must remain disabled.
+      when: bc250_cooling_bypass | bool
+
+  tasks:
+    - name: Detect BC250 hardware before cooling setup
+      ansible.builtin.include_role:
+        name: bc250_hardware
+        tasks_from: detect.yml
+      when: not bc250_cooling_bypass | bool
+
+    - name: Install and start required BC250 fan control
+      ansible.builtin.include_role:
+        name: bc250_hardware
+        tasks_from: fan_control.yml
+      when: not bc250_cooling_bypass | bool
+
+    - name: Validate live fan telemetry and control
+      ansible.builtin.include_role:
+        name: bc250_hardware
+        tasks_from: fan_validate.yml
+      when:
+        - not bc250_cooling_bypass | bool
+        - not ansible_check_mode

--- a/playbooks/25-fan-control.yml
+++ b/playbooks/25-fan-control.yml
@@ -1,0 +1,22 @@
+---
+- name: Configure BC250 fan driver and qualified automatic control
+  hosts: bc250_cluster
+  serial: 1
+  gather_facts: true
+  tags: [fan_control]
+  pre_tasks:
+    - name: Require exactly one explicitly limited fan-control target
+      ansible.builtin.assert:
+        that:
+          - ansible_play_hosts_all | length == 1
+        fail_msg: Fan-control operations require an explicit one-host --limit.
+  tasks:
+    - name: Detect BC250 hardware
+      ansible.builtin.include_role:
+        name: bc250_hardware
+        tasks_from: detect.yml
+
+    - name: Configure pinned fan support
+      ansible.builtin.include_role:
+        name: bc250_hardware
+        tasks_from: fan_control.yml

--- a/roles/bc250_hardware/defaults/main.yml
+++ b/roles/bc250_hardware/defaults/main.yml
@@ -35,6 +35,27 @@ bc250_ttm_enabled: false  # noqa: var-naming[no-role-prefix]
 bc250_ttm_pages_limit: 3014656  # noqa: var-naming[no-role-prefix]
 bc250_ttm_page_pool_size: 3014656  # noqa: var-naming[no-role-prefix]
 
+# NCT6686D cooling is mandatory; channel validation remains per physical board.
+bc250_cooling_required: true  # noqa: var-naming[no-role-prefix]
+bc250_cooling_bypass: false  # noqa: var-naming[no-role-prefix]
+bc250_fan_driver_enabled: true  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_enabled: true  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_channel: 2  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_fan_mask: 2  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_channel_validated: false  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_interval_seconds: 2  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_telemetry_seconds: 10  # noqa: var-naming[no-role-prefix]
+bc250_fan_control_curve:  # noqa: var-naming[no-role-prefix]
+  - {temperature: 40, percent: 45}
+  - {temperature: 55, percent: 55}
+  - {temperature: 65, percent: 70}
+  - {temperature: 75, percent: 90}
+  - {temperature: 80, percent: 100}
+bc250_hardware_nct6687_version: 4864fd681346119cf17417f82934a8ce05d88ff6
+bc250_hardware_nct6687_source_sha256: 5924a508a6d4790c5a32dcae60d331d9ac22d9728452302cd83494514bba07cf
+bc250_hardware_nct6687_source_dir: /usr/local/src/nct6687d
+bc250_hardware_fan_service: bc250-fan-control.service
+
 bc250_hardware_cpu_governor_repo: https://github.com/bc250-collective/bc250_smu_oc.git
 bc250_hardware_cpu_governor_version: 43d6b4c6e38c57bc9ec8908c44675ce7d5fd3d2f
 bc250_hardware_cpu_governor_source_dir: /usr/local/src/bc250_smu_oc

--- a/roles/bc250_hardware/handlers/main.yml
+++ b/roles/bc250_hardware/handlers/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Restart BC250 fan control
+  ansible.builtin.systemd_service:
+    name: "{{ bc250_hardware_fan_service }}"
+    state: restarted
+    daemon_reload: true
 - name: Report BC250 TTM reboot requirement
   ansible.builtin.debug:
     msg: >-

--- a/roles/bc250_hardware/tasks/fan_control.yml
+++ b/roles/bc250_hardware/tasks/fan_control.yml
@@ -1,0 +1,155 @@
+---
+- name: Install NCT6687 build dependencies
+  ansible.builtin.dnf:
+    name:
+      - gcc
+      - make
+      - "kernel-devel-{{ ansible_facts.kernel }}"
+    state: present
+
+- name: Create pinned NCT6687 source directory
+  ansible.builtin.file:
+    path: "{{ bc250_hardware_nct6687_source_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Download pinned upstream NCT6687 driver
+  ansible.builtin.get_url:
+    url: >-
+      https://raw.githubusercontent.com/Fred78290/nct6687d/{{ bc250_hardware_nct6687_version }}/nct6687.c
+    dest: "{{ bc250_hardware_nct6687_source_dir }}/nct6687.c"
+    checksum: "sha256:{{ bc250_hardware_nct6687_source_sha256 }}"
+    owner: root
+    group: root
+    mode: "0644"
+  register: bc250_hardware_fan_driver_source
+  when: not ansible_check_mode
+
+- name: Install NCT6687 Kbuild definition
+  ansible.builtin.copy:
+    dest: "{{ bc250_hardware_nct6687_source_dir }}/Kbuild"
+    content: "obj-m += nct6687.o\n"
+    owner: root
+    group: root
+    mode: "0644"
+  register: bc250_hardware_fan_driver_kbuild
+  when: not ansible_check_mode
+
+- name: Check installed NCT6687 module
+  ansible.builtin.stat:
+    path: "/usr/lib/modules/{{ ansible_facts.kernel }}/extra/nct6687.ko"
+  register: bc250_hardware_fan_module
+  when: not ansible_check_mode
+
+- name: Build pinned NCT6687 module
+  ansible.builtin.command:
+    argv:
+      - make
+      - -C
+      - "/usr/lib/modules/{{ ansible_facts.kernel }}/build"
+      - "M={{ bc250_hardware_nct6687_source_dir }}"
+      - modules
+  changed_when: true
+  when: >-
+    not ansible_check_mode and
+    (bc250_hardware_fan_driver_source.changed or
+    bc250_hardware_fan_driver_kbuild.changed or
+    not bc250_hardware_fan_module.stat.exists)
+
+- name: Create extra kernel module directory
+  ansible.builtin.file:
+    path: "/usr/lib/modules/{{ ansible_facts.kernel }}/extra"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Install pinned NCT6687 module
+  ansible.builtin.copy:
+    src: "{{ bc250_hardware_nct6687_source_dir }}/nct6687.ko"
+    dest: "/usr/lib/modules/{{ ansible_facts.kernel }}/extra/nct6687.ko"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0644"
+  register: bc250_hardware_fan_module_install
+  when: not ansible_check_mode
+
+- name: Refresh module dependencies
+  ansible.builtin.command: "depmod {{ ansible_facts.kernel }}"
+  changed_when: true
+  when: not ansible_check_mode and bc250_hardware_fan_module_install.changed
+
+- name: Configure exclusive NCT6687 driver loading
+  ansible.builtin.copy:
+    dest: /etc/modprobe.d/bc250-nct6687.conf
+    content: |
+      blacklist nct6683
+      options nct6687 force=1 fan_mask={{ bc250_fan_control_fan_mask }}
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Load NCT6687 driver at boot
+  ansible.builtin.copy:
+    dest: /etc/modules-load.d/bc250-nct6687.conf
+    content: "nct6687\n"
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Unload conflicting read-only NCT6683 driver
+  community.general.modprobe:
+    name: nct6683
+    state: absent
+  when: not ansible_check_mode
+
+- name: Load NCT6687 driver
+  community.general.modprobe:
+    name: nct6687
+    params: >-
+      force=1 fan_mask={{ bc250_fan_control_fan_mask }}
+    state: present
+  when: not ansible_check_mode
+
+- name: Require a positively identified fan channel for automatic control
+  ansible.builtin.assert:
+    that:
+      - bc250_fan_control_channel_validated | bool
+      - bc250_fan_control_channel | int >= 1
+      - bc250_fan_control_channel | int <= 8
+      - bc250_fan_control_curve | length >= 2
+    fail_msg: >-
+      Automatic fan control requires a previously qualified physical channel
+      and bc250_fan_control_channel_validated=true.
+  when: bc250_fan_control_enabled | bool
+
+- name: Install fail-safe fan controller
+  ansible.builtin.template:
+    src: bc250-fan-control.py.j2
+    dest: /usr/local/sbin/bc250-fan-control
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart BC250 fan control
+  when: bc250_fan_control_enabled | bool
+
+- name: Install fan controller service
+  ansible.builtin.template:
+    src: bc250-fan-control.service.j2
+    dest: "/etc/systemd/system/{{ bc250_hardware_fan_service }}"
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart BC250 fan control
+  when: bc250_fan_control_enabled | bool
+
+- name: Enable and start fan controller
+  ansible.builtin.systemd_service:
+    name: "{{ bc250_hardware_fan_service }}"
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: bc250_fan_control_enabled | bool

--- a/roles/bc250_hardware/tasks/fan_validate.yml
+++ b/roles/bc250_hardware/tasks/fan_validate.yml
@@ -1,0 +1,39 @@
+---
+- name: Verify fan-control service is enabled
+  ansible.builtin.command:
+    argv: [systemctl, is-enabled, "{{ bc250_hardware_fan_service }}"]
+  changed_when: false
+
+- name: Verify fan-control service is active
+  ansible.builtin.command:
+    argv: [systemctl, is-active, "{{ bc250_hardware_fan_service }}"]
+  changed_when: false
+
+- name: Read qualified fan mode, PWM, and RPM
+  ansible.builtin.shell: |
+    set -o pipefail
+    for path in /sys/class/hwmon/hwmon*; do
+      if [[ $(<"$path/name") == nct6686 ]]; then
+        [[ $(<"$path/fan{{ bc250_fan_control_channel }}_label") == "Pump Fan" ]]
+        printf 'mode=%s pwm=%s rpm=%s\n' \
+          "$(<"$path/pwm{{ bc250_fan_control_channel }}_enable")" \
+          "$(<"$path/pwm{{ bc250_fan_control_channel }}")" \
+          "$(<"$path/fan{{ bc250_fan_control_channel }}_input")"
+        exit 0
+      fi
+    done
+    exit 1
+  args:
+    executable: /bin/bash
+  register: bc250_hardware_fan_telemetry
+  changed_when: false
+
+- name: Require live manual control and tachometer feedback
+  ansible.builtin.assert:
+    that:
+      - bc250_hardware_fan_telemetry.stdout is search('mode=1')
+      - bc250_hardware_fan_telemetry.stdout is not search('rpm=0(?:$| )')
+    fail_msg: >-
+      Required cooling validation failed: the qualified NCT6686D PWM channel
+      is not under controller management or has no RPM feedback. Sustained
+      inference must not be enabled.

--- a/roles/bc250_hardware/templates/bc250-fan-control.py.j2
+++ b/roles/bc250_hardware/templates/bc250-fan-control.py.j2
@@ -1,0 +1,97 @@
+#!/usr/bin/python3
+import logging
+import os
+import signal
+import socket
+import time
+from pathlib import Path
+
+CHANNEL = {{ bc250_fan_control_channel | int }}
+CURVE = {{ bc250_fan_control_curve | to_json }}
+INTERVAL = {{ bc250_fan_control_interval_seconds | int }}
+TELEMETRY = {{ bc250_fan_control_telemetry_seconds | int }}
+running = True
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def hwmon():
+    for path in Path("/sys/class/hwmon").glob("hwmon*"):
+        try:
+            if path.joinpath("name").read_text().strip() == "nct6686":
+                return path
+        except OSError:
+            pass
+    raise RuntimeError("nct6687 hwmon device not found")
+
+
+def temperature():
+    values = []
+    for path in Path("/sys/class/drm").glob("card*/device/hwmon/hwmon*/temp1_input"):
+        try:
+            values.append(int(path.read_text()) / 1000)
+        except (OSError, ValueError):
+            pass
+    if not values:
+        raise RuntimeError("GPU temperature unavailable")
+    return max(values)
+
+
+def percent(temp):
+    if temp <= CURVE[0]["temperature"]:
+        return CURVE[0]["percent"]
+    for low, high in zip(CURVE, CURVE[1:]):
+        if temp <= high["temperature"]:
+            ratio = (temp - low["temperature"]) / (high["temperature"] - low["temperature"])
+            return round(low["percent"] + ratio * (high["percent"] - low["percent"]))
+    return CURVE[-1]["percent"]
+
+
+def automatic(path):
+    path.joinpath(f"pwm{CHANNEL}_enable").write_text("2\n")
+
+
+def notify(message):
+    address = os.environ.get("NOTIFY_SOCKET")
+    if not address:
+        return
+    if address.startswith("@"):
+        address = "\0" + address[1:]
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as channel:
+        channel.connect(address)
+        channel.sendall(message.encode())
+
+
+def stop(_signum, _frame):
+    global running
+    running = False
+
+
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+device = hwmon()
+label = device.joinpath(f"fan{CHANNEL}_label")
+if label.exists() and label.read_text().strip() != "Pump Fan":
+    raise RuntimeError(f"channel {CHANNEL} label is not Pump Fan")
+pwm = device.joinpath(f"pwm{CHANNEL}")
+enable = device.joinpath(f"pwm{CHANNEL}_enable")
+rpm = device.joinpath(f"fan{CHANNEL}_input")
+last_log = 0.0
+try:
+    notify("READY=1")
+    while running:
+        temp = temperature()
+        duty = percent(temp)
+        enable.write_text("1\n")
+        pwm.write_text(f"{round(duty * 255 / 100)}\n")
+        now = time.monotonic()
+        if now - last_log >= TELEMETRY:
+            fan_rpm = int(rpm.read_text())
+            logging.info("gpu_temp_c=%.1f fan_percent=%d fan_rpm=%d", temp, duty, fan_rpm)
+            if fan_rpm <= 0:
+                raise RuntimeError("qualified fan tachometer reports zero RPM")
+            last_log = now
+        notify("WATCHDOG=1")
+        time.sleep(INTERVAL)
+finally:
+    automatic(device)

--- a/roles/bc250_hardware/templates/bc250-fan-control.service.j2
+++ b/roles/bc250_hardware/templates/bc250-fan-control.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=BC250 fail-safe GPU fan curve
+After=systemd-modules-load.service
+Requires=systemd-modules-load.service
+
+[Service]
+Type=notify
+ExecStart=/usr/local/sbin/bc250-fan-control
+ExecStopPost=/bin/sh -c 'for d in /sys/class/hwmon/hwmon*; do [ "$(cat "$d/name" 2>/dev/null)" = nct6686 ] && echo 2 > "$d/pwm{{ bc250_fan_control_channel | int }}_enable"; done'
+Restart=on-failure
+RestartSec=2
+WatchdogSec=10
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/cluster/defaults/main.yml
+++ b/roles/cluster/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 cluster_llama_environment_dir: /etc/llama.cpp
 cluster_llama_model_path: "{{ llama_model_dir }}/{{ llama_model_filename }}"
+llama_jinja_enabled: false  # noqa: var-naming[no-role-prefix]
+llama_prompt_cache_ram_mib: null  # noqa: var-naming[no-role-prefix]
+llama_cache_idle_slots_enabled: true  # noqa: var-naming[no-role-prefix]
+llama_parallel_slots: 1  # noqa: var-naming[no-role-prefix]

--- a/roles/cluster/tasks/main.yml
+++ b/roles/cluster/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Refuse production inference without qualified cooling
+  ansible.builtin.assert:
+    that:
+      - not (bc250_cooling_bypass | default(false) | bool)
+      - bc250_fan_control_enabled | default(false) | bool
+      - bc250_fan_control_channel_validated | default(false) | bool
+    fail_msg: >-
+      llama.cpp production services require qualified automatic fan control.
+      A cooling bypass is non-production and cannot enable inference services.
+
 - name: Create llama.cpp service group
   ansible.builtin.group:
     name: "{{ llama_system_group }}"

--- a/roles/cluster/templates/llama-rpc-server.service.j2
+++ b/roles/cluster/templates/llama-rpc-server.service.j2
@@ -3,6 +3,10 @@ Description=llama.cpp Vulkan RPC worker
 Documentation=https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc
 Wants=network-online.target
 After=network-online.target
+{% if not (bc250_cooling_bypass | default(false) | bool) %}
+Requires=bc250-fan-control.service
+After=bc250-fan-control.service
+{% endif %}
 
 [Service]
 Type=simple

--- a/roles/cluster/templates/llama-server.service.j2
+++ b/roles/cluster/templates/llama-server.service.j2
@@ -3,13 +3,17 @@ Description=Distributed llama.cpp inference coordinator
 Documentation=https://github.com/ggml-org/llama.cpp/tree/master/tools/server
 Wants=network-online.target
 After=network-online.target
+{% if not (bc250_cooling_bypass | default(false) | bool) %}
+Requires=bc250-fan-control.service
+After=bc250-fan-control.service
+{% endif %}
 
 [Service]
 Type=simple
 User={{ llama_system_user }}
 Group={{ llama_system_group }}
 SupplementaryGroups=render video
-ExecStart={{ llama_cpp_current_path }}/bin/llama-server{% if llama_model_filename | length > 0 %} --model {{ cluster_llama_model_path }}{% else %} --models-dir {{ llama_model_dir }} --models-max {{ llama_models_max }}{% endif %} --host {{ management_ip }} --port {{ llama_api_port }} --rpc {% for host in groups.llama_rpc_workers %}{{ hostvars[host].backend_ip }}:{{ llama_rpc_port }}{% if not loop.last %},{% endif %}{% endfor %} --gpu-layers {{ llama_gpu_layers }} --split-mode {{ llama_split_mode }} --ctx-size {{ llama_context_size }} --cache-type-k {{ llama_cache_type_k }} --cache-type-v {{ llama_cache_type_v }}{{ (' --tensor-split ' ~ (llama_tensor_split | join(','))) if llama_tensor_split | length > 0 else '' }}
+ExecStart={{ llama_cpp_current_path }}/bin/llama-server{% if llama_model_filename | length > 0 %} --model {{ cluster_llama_model_path }}{% else %} --models-dir {{ llama_model_dir }} --models-max {{ llama_models_max }}{% endif %} --host {{ management_ip }} --port {{ llama_api_port }} --rpc {% for host in groups.llama_rpc_workers %}{{ hostvars[host].backend_ip }}:{{ llama_rpc_port }}{% if not loop.last %},{% endif %}{% endfor %} --gpu-layers {{ llama_gpu_layers }} --split-mode {{ llama_split_mode }} --ctx-size {{ llama_context_size }} --parallel {{ llama_parallel_slots }} --cache-type-k {{ llama_cache_type_k }} --cache-type-v {{ llama_cache_type_v }}{{ (' --tensor-split ' ~ (llama_tensor_split | join(','))) if llama_tensor_split | length > 0 else '' }}{{ ' --jinja' if llama_jinja_enabled | bool else '' }}{{ (' --cache-ram ' ~ llama_prompt_cache_ram_mib) if llama_prompt_cache_ram_mib is not none else '' }}{{ '' if llama_cache_idle_slots_enabled | bool else ' --no-cache-idle-slots' }}
 Restart=on-failure
 RestartSec=5
 TimeoutStartSec=300

--- a/roles/validation/tasks/main.yml
+++ b/roles/validation/tasks/main.yml
@@ -168,6 +168,35 @@
     - bc250_gpu_governor_enabled | bool
     - bc250_gpu_governor_performance_mode_enabled | bool
 
+- name: Verify qualified BC250 fan controller is active
+  ansible.builtin.command:
+    argv: [systemctl, is-active, bc250-fan-control.service]
+  changed_when: false
+  when: bc250_fan_control_enabled | bool
+
+- name: Read qualified BC250 fan telemetry
+  ansible.builtin.shell: |
+    set -o pipefail
+    for path in /sys/class/hwmon/hwmon*; do
+      if [[ $(<"$path/name") == nct6686 ]]; then
+        printf 'mode=%s pwm=%s rpm=%s\n' \
+          "$(<"$path/pwm{{ bc250_fan_control_channel }}_enable")" \
+          "$(<"$path/pwm{{ bc250_fan_control_channel }}")" \
+          "$(<"$path/fan{{ bc250_fan_control_channel }}_input")"
+        exit 0
+      fi
+    done
+    exit 1
+  args:
+    executable: /bin/bash
+  register: validation_fan_telemetry
+  changed_when: false
+  failed_when: >-
+    validation_fan_telemetry.rc != 0 or
+    validation_fan_telemetry.stdout is not search('mode=1') or
+    validation_fan_telemetry.stdout is search('rpm=0(?:$| )')
+  when: bc250_fan_control_enabled | bool
+
 - name: Read backend interface from NetworkManager
   ansible.builtin.command:
     argv: [nmcli, -g, GENERAL.DEVICES, connection, show, "{{ backend_connection_name }}"]

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,8 @@
   ansible.builtin.import_playbook: playbooks/00-preflight.yml
 - name: Configure base operating system
   ansible.builtin.import_playbook: playbooks/10-base.yml
+- name: Establish required BC250 cooling
+  ansible.builtin.import_playbook: playbooks/15-cooling.yml
 - name: Establish BC250 hardware baseline
   ansible.builtin.import_playbook: playbooks/20-hardware.yml
 - name: Configure backend network


### PR DESCRIPTION
Install the pinned NCT6687 driver and fail-safe fan controller before hardware tuning, validate live PWM/RPM telemetry, and order inference services after cooling. Promote the qualified one-slot Qwen3.6 service flags and document the production workflow.